### PR TITLE
Fixes Composer installation issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,5 +14,8 @@
     "require": {
         "php": ">=5.3.0",
         "composer/installers": "*"
+    },
+    "extra": {
+        "installer-name": "Gearman"
     }
 }


### PR DESCRIPTION
Fixes an issue discovered at CakeFest 2013 where composer installs the plugin as `CakephpGerman` and it should be `Gearman`.

NOTE: I can't test how composer uses this version of the file on my local machine but this _should_ fix the issue according to the composer docs. See: https://github.com/composer/installers#custom-install-names
